### PR TITLE
Update manifest

### DIFF
--- a/flatpak/org.freedesktop.Sdk.Extension.innative.yml
+++ b/flatpak/org.freedesktop.Sdk.Extension.innative.yml
@@ -14,23 +14,24 @@ modules:
                   - mkdir bin
                   - mv llvm bin
                   - sed -i "s@c++1.@c++17@g" innative{,-cmd}/Makefile 
-                  - sed -i "s@-lstdc++fs@@" innative-{cmd,test}/Makefile
+                  - sed -i "s@-lstdc++fs@@g" innative-{cmd,test}/Makefile
                   - make
+                  - install -d /usr/lib/sdk/innative/include/innative
                   - install -d /usr/lib/sdk/innative/bin
                   - install -d /usr/lib/sdk/innative/lib
                   - install -d /usr/lib/sdk/innative/spec/test
                   - cp -r spec /usr/lib/sdk/innative/spec
+                  - cp bin/llvm/include/innative/*.h /usr/lib/sdk/innative/include/innative
                   - cp bin/{innative-cmd,innative-test} /usr/lib/sdk/innative/bin
                   - cp bin/{innative-env.a,innative-env-d.a,innative-test-embedding.a} /usr/lib/sdk/innative/lib
-                  - cp bin/libinnative.so /usr/lib/sdk/innative/lib/libinnative.so.0.1.3
+                  - cp bin/libinnative.so /usr/lib/sdk/innative/lib/libinnative.so.0.1.4
                   - cp -r innative-test /usr/lib/sdk/innative/innative-test
                   - cp -r scripts /usr/lib/sdk/innative/scripts
                   - cp -r innative /usr/lib/sdk/innative/innative
-                  - ln -s libinnative.so.0.1.3 /usr/lib/sdk/innative/lib/libinnative.so
+                  - ln -s libinnative.so.0.1.4 /usr/lib/sdk/innative/lib/libinnative.so
           sources:
                   - type: git
                     url: https://github.com/innative-sdk/innative
-                    commit: 99760fc9c0f08e940f0888122bb44e0ec5321d82
                   - type: archive
                     url: https://github.com/innative-sdk/llvm-project/releases/download/v9.0.0-innative/llvm-9.0.0-x86-64-linux-ubuntu-18.tar.gz
                     sha1: 3b6ec7d39f02b0e15c70c717e53a2b3513720fe4 


### PR DESCRIPTION
This is a small update to fix the version string of the symlink, build off of master instead of a specific commit, and to include headers that would've been installed via `make install`